### PR TITLE
Fix: Adjust arrow endpoints and increase container height

### DIFF
--- a/modelos-contratacao-source (1)/modelos-contratacao/public/decision_tree.html
+++ b/modelos-contratacao-source (1)/modelos-contratacao/public/decision_tree.html
@@ -27,7 +27,7 @@
             box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
             max-width: 1000px;
             width: 100%;
-            min-height: 600px;
+            min-height: 750px; /* Increased from 600px */
             position: relative;
             /* overflow: hidden; // Removed to allow button to be outside if needed, though it will be inside */
         }
@@ -75,7 +75,7 @@
         .tree-container {
             position: relative; /* Needed for absolute positioning of sim-resultado-nodes and SVG canvas */
             padding: 2rem;
-            min-height: 500px;
+            min-height: 600px; /* Increased from 500px */
             /* overflow-y: auto; /* Consider adding if vertical content still overflows */
         }
 
@@ -289,7 +289,7 @@
         <div class="tree-container">
             <svg class="arrow-canvas" width="100%" height="100%">
                 <defs>
-                    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="0" refY="3.5" orient="auto" markerUnits="strokeWidth">
+                    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto" markerUnits="userSpaceOnUse">
                         <polygon points="0 0, 10 3.5, 0 7" fill="#667eea" />
                     </marker>
                 </defs>


### PR DESCRIPTION
- Modified SVG arrowhead marker definition (`refX`, `markerUnits`) to ensure the tip of the arrow aligns precisely with the target node's border.
- Increased `min-height` of the main container and tree container to provide more vertical space, reducing the need for scrolling on common paths.
- Verified arrow drawing and clearing logic remains correct.