### PR TITLE
Feat: Increase iframe height for decision tree

### DIFF
--- a/modelos-contratacao-source (1)/modelos-contratacao/src/App.jsx
+++ b/modelos-contratacao-source (1)/modelos-contratacao/src/App.jsx
@@ -245,7 +245,7 @@ function App() {
                   <iframe
                     src="/decision_tree.html"
                     title="Fluxograma de Decisão Interativo"
-                    className="w-full h-[700px] rounded-lg border-none"
+                    className="w-full h-[950px] rounded-lg border-none"
                   />
                 </div>
               </CardContent>


### PR DESCRIPTION
Increased the height of the iframe embedding the decision tree in App.jsx from 700px to 950px to better accommodate longer decision paths and reduce scrolling.

Arrow management logic was previously confirmed to correctly clear arrows when their target 'Sim' node is no longer active.